### PR TITLE
Fix minor issue in tr.yml

### DIFF
--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -1,5 +1,5 @@
 # Turkish strings sorted alphabetically wrt first letter.
-en:
+tr:
   button_delete: "Sil"
   button_send_now: "Gönder"
 


### PR DESCRIPTION
Top level of structure causes collision with English locale. In our case this caused all "delete" buttons to display "Sil".